### PR TITLE
Terms query with empty values support

### DIFF
--- a/es.query.builder.gemspec
+++ b/es.query.builder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'es_query_builder'
-  s.version     = '2.0.2'
+  s.version     = '2.0.3'
   s.summary     = 'For Building Elastic Search Queries'
   s.authors     = ['Mohib Yousuf', 'Anurag Agrawal', 'Supantha Samanta', 'Neeraj Joshi']
   s.email       = ['mohib.yousuf@hotmail.com', 'anuragagrawal117@gmail.com', 'supantha.samanta@gmail.com', 'neerajjoshi00@gmail.com']

--- a/lib/queries/terms_query_builder.rb
+++ b/lib/queries/terms_query_builder.rb
@@ -32,7 +32,7 @@ module Queries
     def query
       query = {}
       terms_query = self.common_query
-      terms_query[@field_name.intern] = @values if @values.present?
+      terms_query[@field_name.intern] = @values
       terms_query[@field_name.intern] = @terms_lookup.settings if @terms_lookup.present?
       query[name.intern] = terms_query
       return query


### PR DESCRIPTION
Earlier `QueryBuilders.terms_query(field_name: 'abc', values: []).query` returned `{:terms=>{}}`
And now, it return `{:terms=>{:abc=>[]}}`